### PR TITLE
ApiPromiseFactory and XCM backends unification

### DIFF
--- a/packages/simple-xcm/registry.ts
+++ b/packages/simple-xcm/registry.ts
@@ -7,7 +7,6 @@ import {
   prodParasKusamaCommon,
   prodParasKusama,
 } from '@polkadot/apps-config';
-import {ApiPromise, WsProvider} from '@polkadot/api';
 import {
   ChainInfo,
   CurrencyInfo,
@@ -28,6 +27,14 @@ import {
   sanitizeInterior,
   sanitizeLocation,
 } from '@open-xcm-tools/xcm-util';
+import {
+  ApiPromiseFactory,
+  defaultApiPromiseFactory,
+} from '@open-xcm-tools/xcm-util/api-promise';
+
+export type RegistryOptions = {
+  apiPromiseFactory?: ApiPromiseFactory;
+};
 
 /**
  * A `Registry` object can store and then provide information about chains, currencies, and locations.
@@ -43,12 +50,15 @@ export class Registry {
   universalLocations: Map<string, InteriorLocation>;
   relativeLocations: Map<string, Location>;
   currencyInfos: Map<string, CurrencyInfo>;
+  apiPromiseFactory: ApiPromiseFactory;
 
-  constructor() {
+  constructor(registryOptions?: RegistryOptions) {
     this.chainInfos = new Map();
     this.universalLocations = new Map();
     this.relativeLocations = new Map();
     this.currencyInfos = new Map();
+    this.apiPromiseFactory =
+      registryOptions?.apiPromiseFactory || defaultApiPromiseFactory;
   }
 
   /**
@@ -184,9 +194,7 @@ export class Registry {
    */
   async addNativeCurrency(chainName: string): Promise<void> {
     const chainInfo = this.chainInfoByName(chainName);
-
-    const provider = new WsProvider(chainInfo.endpoints);
-    const api = await ApiPromise.create({provider});
+    const api = await this.apiPromiseFactory(chainInfo.endpoints);
 
     if (api.registry.chainTokens.length > 0) {
       const symbol = api.registry.chainTokens[0];

--- a/packages/simple-xcm/simplexcm.ts
+++ b/packages/simple-xcm/simplexcm.ts
@@ -106,6 +106,26 @@ export class SimpleXcm {
   xcmVersion: XcmVersion;
 
   /**
+   * Composes an extrinsic for a transfer based on the provided parameters.
+   *
+   * Note:Be aware that this method does not dry-run the extrinsic or estimate/adjust the fees.
+   * @param transferParams
+   */
+  async composeExtrinsic(
+    transferParams: TransferParams,
+  ): Promise<
+    Pick<ComposedXcmTransfer, 'submittableExtrinsic' | 'preparedParams'>
+  > {
+    const preparedParams =
+      await this.#transferBackend().prepareTransferParams(transferParams);
+
+    const submittableExtrinsic =
+      this.#transferBackend().buildSubmittableExtrinsic(preparedParams);
+
+    return {submittableExtrinsic, preparedParams};
+  }
+
+  /**
    * Composes a transfer extrinsic based on the provided parameters.
    * @param transferParams - The parameters for the transfer.
    * @returns A promise that resolves to a SubmittableExtrinsic for the transfer.
@@ -330,7 +350,7 @@ export class SimpleXcm {
     feeAssetId: AssetId,
   ): Promise<{value: bigint} | {error: TooExpensiveFeeError}> {
     try {
-      const estimatedFees = await this.estimator.tryEstimateExtrinsicFees(
+      const estimatedFees = await this.estimator.tryEstimateXcmFees(
         origin,
         tx,
         feeAssetId,

--- a/packages/simple-xcm/simplexcm.ts
+++ b/packages/simple-xcm/simplexcm.ts
@@ -128,10 +128,10 @@ export class SimpleXcm {
     );
 
     if ('error' in estimatedFeesResult) {
-      preparedParams.feeAnyAssetRef.fun.fungible +=
-        estimatedFeesResult.error.missingAmount;
+      const missingAmount = estimatedFeesResult.error.missingAmount;
 
-      estimatedFees = preparedParams.feeAnyAssetRef.fun.fungible;
+      preparedParams.feeAnyAssetRef.fun.fungible += missingAmount;
+      estimatedFees = missingAmount;
     } else {
       estimatedFees = estimatedFeesResult.value;
     }

--- a/packages/simple-xcm/simplexcm.ts
+++ b/packages/simple-xcm/simplexcm.ts
@@ -1,4 +1,4 @@
-import {ApiPromise, WsProvider} from '@polkadot/api';
+import type {ApiPromise} from '@polkadot/api';
 import {SubmittableExtrinsic} from '@polkadot/api/types';
 import {Bytes, Result} from '@polkadot/types-codec';
 import {Codec} from '@polkadot/types-codec/types';
@@ -191,9 +191,7 @@ export class SimpleXcm {
    */
   static async connect(chainName: string, registry: Registry) {
     const chainInfo = registry.chainInfoByName(chainName);
-
-    const provider = new WsProvider(chainInfo.endpoints);
-    const api = await ApiPromise.create({provider});
+    const api = await registry.apiPromiseFactory(chainInfo.endpoints);
 
     const palletXcm = findPalletXcm(api);
     if (!palletXcm) {
@@ -298,6 +296,7 @@ export class SimpleXcm {
           estimatorResolver: (universalLocation: InteriorLocation) =>
             Estimator.connect(
               this.registry.chainInfoByUniversalLocation(universalLocation),
+              this.registry.apiPromiseFactory,
             ),
         },
       );

--- a/packages/xcm-estimate/estimator.ts
+++ b/packages/xcm-estimate/estimator.ts
@@ -270,7 +270,7 @@ export class Estimator {
    * @returns A promise that resolves to the estimated fee.
    * @throws If the estimation fails.
    */
-  async tryEstimateExtrinsicFees(
+  async tryEstimateXcmFees(
     origin: Origin,
     xt: SubmittableExtrinsic<'promise'>,
     feeAssetId: AssetId,

--- a/packages/xcm-estimate/estimator.ts
+++ b/packages/xcm-estimate/estimator.ts
@@ -1,4 +1,4 @@
-import {ApiPromise, WsProvider} from '@polkadot/api';
+import type {ApiPromise} from '@polkadot/api';
 import {
   Asset,
   AssetId,
@@ -23,6 +23,7 @@ import {
   TooExpensiveFeeError,
 } from './errors';
 import {
+  type ApiPromiseFactory,
   assetIdIntoCurrentVersion,
   assetsIntoCurrentVersion,
   compareLocation,
@@ -112,15 +113,16 @@ export class Estimator {
 
   /**
    * Connects to the specified chain and creates an Estimator instance.
-   * This method is solely for the convenience of creating ApiPromise internally.
-   * If you already have an ApiPromise instance, please use the constructor instead.
    * @param chainInfo - Information about the chain to connect to.
+   * @param apiPromiseFactory - The factory for creating ApiPromise instances. Optional.
    * @returns A promise that resolves to an Estimator instance.
    */
-  static async connect(chainInfo: ChainInfo) {
-    const api = await ApiPromise.create({
-      provider: new WsProvider(chainInfo.endpoints),
-    });
+  static async connect(
+    chainInfo: ChainInfo,
+    apiPromiseFactory: ApiPromiseFactory,
+  ) {
+    const api = await apiPromiseFactory(chainInfo.endpoints);
+
     const maxXcmVersion = await Estimator.estimateMaxXcmVersion(
       api,
       chainInfo.identity.name,

--- a/packages/xcm-util/api-promise/index.ts
+++ b/packages/xcm-util/api-promise/index.ts
@@ -1,0 +1,18 @@
+import {ApiPromise, WsProvider} from '@polkadot/api';
+
+export type ApiPromiseFactory = (endpoints: string[]) => Promise<ApiPromise>;
+
+/**
+ * Default implementation of the `ApiPromiseFactory` interface.
+ *
+ * Note: This is a most straightforward implementation that creates a new `ApiPromise` instance for each call.
+ * In many cases, you may want to implement your own factory function to manage and reuse the ApiPromise instances.
+ * @param endpoints - The list of websocket endpoints to connect to.
+ */
+export const defaultApiPromiseFactory: ApiPromiseFactory = (
+  endpoints: string[],
+) => {
+  const provider = new WsProvider(endpoints);
+
+  return ApiPromise.create({provider});
+};

--- a/packages/xcm-util/index.ts
+++ b/packages/xcm-util/index.ts
@@ -50,3 +50,6 @@ export {
   sanitizeJunction,
   sanitizeLocation,
 } from './sanitize';
+
+export type {ApiPromiseFactory} from './api-promise';
+export {defaultApiPromiseFactory} from './api-promise';

--- a/tests/integration/fee-estimation.test.ts
+++ b/tests/integration/fee-estimation.test.ts
@@ -158,9 +158,9 @@ describe('fee estimation tests', async () => {
 
     const transferAmount = params.transferAmount;
 
-    let tx;
+    let transfer;
     try {
-      tx = await params.fromXcm.composeTransfer({
+      transfer = await params.fromXcm.composeTransfer({
         origin: 'Alice',
         assets: [
           params.fromXcm.adjustedFungible(
@@ -176,7 +176,7 @@ describe('fee estimation tests', async () => {
       throw 'errors' in error ? error.errors : error;
     }
 
-    await tryUntilFinalized(alice, tx);
+    await tryUntilFinalized(alice, transfer.submittableExtrinsic);
 
     const newBalance = await pauseUntilPseudoUsdBalanceIncreased(
       params.destXcm,

--- a/tests/integration/testutil.ts
+++ b/tests/integration/testutil.ts
@@ -146,7 +146,7 @@ export function extrinsicRelayRootXcmSendUnpaidTransact(
   api: ApiPromise,
   tx: SubmittableExtrinsic<'promise'>,
   destParaId: number,
-) {
+): SubmittableExtrinsic<'promise'> {
   return api.tx.sudo.sudo(
     api.tx.xcmPallet.send(
       {
@@ -271,17 +271,16 @@ async function relayXcmSendCreatePseudoUsd(
     assetsPalletName,
     owner,
   );
+
   if (createExtrinsic === null) {
     return null;
   }
 
-  const sendExtrinsic = extrinsicRelayRootXcmSendUnpaidTransact(
+  return extrinsicRelayRootXcmSendUnpaidTransact(
     xcmRelay.api,
     createExtrinsic,
     await getParaId(xcmDest.api),
   );
-
-  return sendExtrinsic;
 }
 
 async function extrinsicCreatePseudoUsd(


### PR DESCRIPTION
- added optional `ApiPromiseFactory` to `Registry` and `Estimator`. This allows library users to have more control over `ApiPromise` instances when needed.

- refactored code in `simplexcm.ts` so that `TransferBackend` implementations now contain only pallet-related logic.