### PR TITLE
refactored simplexcm.ts

### DIFF
--- a/packages/simple-xcm/index.ts
+++ b/packages/simple-xcm/index.ts
@@ -1,5 +1,10 @@
 export {Registry} from './registry';
-export {SimpleXcm, TransferParams} from './simplexcm';
+export {SimpleXcm} from './simplexcm';
+export type {
+  TransferParams,
+  PreparedTransferParams,
+  ComposedXcmTransfer,
+} from './simplexcm';
 export {
   isChainUniversalLocation,
   parachainUniversalLocation,

--- a/packages/simple-xcm/simplexcm.ts
+++ b/packages/simple-xcm/simplexcm.ts
@@ -167,6 +167,12 @@ export class SimpleXcm {
     const submittableExtrinsic =
       this.#transferBackend().buildSubmittableExtrinsic(preparedParams);
 
+    await Estimator.dryRunExtrinsic(
+      this.api,
+      preparedParams.origin,
+      submittableExtrinsic,
+    );
+
     const estimatedFees = estimatedFeesResult.value;
 
     return {submittableExtrinsic, preparedParams, estimatedFees};

--- a/packages/xcm-estimate/estimator.ts
+++ b/packages/xcm-estimate/estimator.ts
@@ -270,7 +270,7 @@ export class Estimator {
    * @returns A promise that resolves to the estimated fee.
    * @throws If the estimation fails.
    */
-  async tryEstimateExtrinsicFees(
+  async tryEstimateXcmFees(
     origin: Origin,
     xt: SubmittableExtrinsic<'promise'>,
     feeAssetId: AssetId,

--- a/tests/integration/fee-estimation.test.ts
+++ b/tests/integration/fee-estimation.test.ts
@@ -3,6 +3,7 @@ import {
   Registry,
   relaychainUniversalLocation,
   SimpleXcm,
+  ComposedXcmTransfer,
 } from '@open-xcm-tools/simple-xcm';
 import {universalLocation, location} from '@open-xcm-tools/xcm-util';
 import {NetworkId} from '@open-xcm-tools/xcm-types';
@@ -235,9 +236,9 @@ describe('fee estimation tests', async () => {
 
     const transferAmount = params.transferAmount;
 
-    let tx;
+    let transfer: ComposedXcmTransfer;
     try {
-      tx = await params.fromXcm.composeTransfer({
+      transfer = await params.fromXcm.composeTransfer({
         origin: 'Alice',
         assets: [
           params.fromXcm.adjustedFungible(
@@ -253,7 +254,7 @@ describe('fee estimation tests', async () => {
       throw 'errors' in error ? error.errors : error;
     }
 
-    await tryUntilFinalized(alice, tx);
+    await tryUntilFinalized(alice, transfer.submittableExtrinsic);
 
     const newBalance = await pauseUntilPseudoUsdBalanceIncreased(
       params.destXcm,


### PR DESCRIPTION
- TransferBackend implementations now hold all pallet-related logic
- composeTransfer now returns not just submittableExtrinsic, but also XCM fees and additional details